### PR TITLE
Make Appstatus bean closable in order to shutdown executorService.

### DIFF
--- a/appstatus-core/src/main/java/net/sf/appstatus/core/AppStatus.java
+++ b/appstatus-core/src/main/java/net/sf/appstatus/core/AppStatus.java
@@ -15,6 +15,7 @@
  */
 package net.sf.appstatus.core;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,16 +56,19 @@ import net.sf.appstatus.core.services.IServiceMonitor;
  * This is the entry point for every feature of AppStatus.
  *
  * <p>
- * Must be initialized once before calling other methods.
+ * Must be initialized once before calling other methods and closed when
+ * application is stopping.
  * <p>
  * AppStatus status = new AppStatus(); <br/>
- * status.init();
+ * status.init(); <br/>
+ * ... <br/>
+ * status.close();
  * </p>
  *
  * @author Nicolas Richeton
  *
  */
-public class AppStatus {
+public class AppStatus implements Closeable {
 
     private static final String CONFIG_LOCATION = "status-check.properties";
     private static Logger logger = LoggerFactory.getLogger(AppStatus.class);
@@ -73,7 +77,7 @@ public class AppStatus {
     private IBatchScheduleManager batchScheduleManager;
     protected List<ICheck> checkers;
     private Properties configuration = null;
-    private ExecutorService executorService = null;
+    protected ExecutorService executorService = null;
     private boolean initDone = false;
     private ILoggersManager loggersManager = null;
     private boolean maintenance = false;
@@ -166,6 +170,12 @@ public class AppStatus {
         if (!initDone) {
             logger.warn("Not initialized. Starting init");
             init();
+        }
+    }
+
+    public synchronized void close() {
+        if (executorService != null) {
+            executorService.shutdownNow();
         }
     }
 

--- a/appstatus-core/src/test/java/net/sf/appstatus/StatusServiceTest.java
+++ b/appstatus-core/src/test/java/net/sf/appstatus/StatusServiceTest.java
@@ -1,18 +1,21 @@
 package net.sf.appstatus;
 
 import static org.junit.Assert.assertTrue;
-import net.sf.appstatus.core.AppStatus;
-import net.sf.appstatus.core.check.impl.StatusResultImpl;
 
 import org.junit.Test;
 
+import net.sf.appstatus.core.AppStatus;
+import net.sf.appstatus.core.check.impl.StatusResultImpl;
+
 public class StatusServiceTest extends AppStatus {
 
-  public StatusResultImpl result;
+    public StatusResultImpl result;
 
-  @Test
-  public void testInitialization() throws Exception {
-    this.init();
-    assertTrue(checkers.size() > 0);
-  }
+    @Test
+    public void testInitialization() throws Exception {
+        this.init();
+        assertTrue(checkers.size() > 0);
+        this.close();
+        assertTrue(executorService == null || (executorService.isTerminated() && executorService.isShutdown()));
+    }
 }

--- a/appstatus-demo-spring/src/main/resources/spring-conf.xml
+++ b/appstatus-demo-spring/src/main/resources/spring-conf.xml
@@ -9,7 +9,7 @@
 	 http://www.springframework.org/schema/aop  http://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<bean id="appstatus" class="net.sf.appstatus.core.AppStatus"
-		init-method="init" scope="singleton">
+		init-method="init" destroy-method="close" scope="singleton">
 		<property name="objectInstanciationListener">
 			<bean
 				class="net.sf.appstatus.support.spring.SpringObjectInstantiationListener" />


### PR DESCRIPTION
Fix memory leak when tomcat shutdown :
"The web application [***] appears to have started a thread named
[pool-2-thread-1] but has failed to stop it. This is very likely to
create a memory leak."