### PR TITLE
StatusPage.java, doGetJSON doesnt work

### DIFF
--- a/appstatus-web/src/main/java/net/sf/appstatus/web/pages/StatusPage.java
+++ b/appstatus-web/src/main/java/net/sf/appstatus/web/pages/StatusPage.java
@@ -165,7 +165,7 @@ public class StatusPage extends AbstractPage {
 		int statusCode = 200;
 		final List<ICheckResult> results = appStatus.checkAll(req.getLocale());
 		for (final ICheckResult r : results) {
-			if (r.isFatal()) {
+			if (r.getCode() != ICheckResult.OK && r.isFatal()) {
 				resp.setStatus(500);
 				statusCode = 500;
 				break;


### PR DESCRIPTION
Correcting an issue : if the checker is fatal, the doGetJSON always return 500, even if the checkResult is OK.